### PR TITLE
Issue/#13/auth 로직 구현

### DIFF
--- a/Modungji/App/ModungjiApp.swift
+++ b/Modungji/App/ModungjiApp.swift
@@ -13,9 +13,17 @@ import ModungjiSecret
 
 @main
 struct ModungjiApp: App {
+    @StateObject private var authViewModel: AuthViewModel
     
     init() {
         KakaoSDK.initSDK(appKey: ModungjiSecret.Kakao.key)
+        
+        let authRepository = AuthRepositoryImp(networkManager: NetworkManager(), kakaoManager: KakaoManager(), keychainManger: KeychainManager())
+        let authService = AuthServiceImp(
+            repository: authRepository
+        )
+        
+        self._authViewModel = StateObject(wrappedValue: AuthViewModel(service: authService))
     }
     
     var body: some Scene {
@@ -33,6 +41,7 @@ struct ModungjiApp: App {
                         }
                     }
             }
+            .environmentObject(authViewModel)
         }
     }
 }

--- a/Modungji/Core/Kakao/KakaoManager.swift
+++ b/Modungji/Core/Kakao/KakaoManager.swift
@@ -1,0 +1,40 @@
+//
+//  KakaoManager.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+import KakaoSDKAuth
+import KakaoSDKUser
+
+final class KakaoManager {
+    
+    @MainActor
+    func requestLogin() async -> OAuthToken? {
+        await withCheckedContinuation { continuation in
+            // 카카오톡 설치 여부 체크
+            if UserApi.isKakaoTalkLoginAvailable() {
+                // 카카오톡으로 로그인
+                UserApi.shared.loginWithKakaoTalk { token, error in
+                    if let error {
+                        continuation.resume(returning: nil)
+                    }
+                    
+                    continuation.resume(returning: token)
+                }
+            } else {
+                // 카카오 계정으로 로그인
+                UserApi.shared.loginWithKakaoAccount { token, error in
+                    if let error {
+                        continuation.resume(returning: nil)
+                    }
+                    
+                    continuation.resume(returning: token)
+                }
+            }
+        }
+    }
+}

--- a/Modungji/Core/Keychain/KeychainManager.swift
+++ b/Modungji/Core/Keychain/KeychainManager.swift
@@ -16,13 +16,13 @@ final class KeychainManager {
         
         var query: NSMutableDictionary {
             return [
-                kSecClass: kSecClassKey,
-                kSecAttrLabel: self.rawValue
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrAccount: self.rawValue
             ]
         }
     }
     
-    static func saveToken(tokenType: TokenType, token: String) throws(KeychainError) {
+    func saveToken(tokenType: TokenType, token: String) throws {
         let query = tokenType.query
         
         guard let encodedToken = token.data(using: .utf8) else {
@@ -39,7 +39,7 @@ final class KeychainManager {
         }
     }
     
-    static func getToken(tokenType: TokenType) throws(KeychainError) -> String {
+    func getToken(tokenType: TokenType) throws(KeychainError) -> String {
         let query = tokenType.query
         query[kSecMatchLimit] = kSecMatchLimitOne
         query[kSecReturnData] = kCFBooleanTrue
@@ -62,7 +62,7 @@ final class KeychainManager {
         return token
     }
     
-    static func deleteToken(tokenType: TokenType) throws(KeychainError) {
+    func deleteToken(tokenType: TokenType) throws(KeychainError) {
         let query = tokenType.query
         let status = SecItemDelete(query)
         

--- a/Modungji/Core/Network/NetworkError.swift
+++ b/Modungji/Core/Network/NetworkError.swift
@@ -12,4 +12,5 @@ enum NetworkError: Error {
     case invalidResponse
     case decodingError
     case encodingError
+    case unknown
 }

--- a/Modungji/Core/Network/NetworkManager.swift
+++ b/Modungji/Core/Network/NetworkManager.swift
@@ -26,10 +26,16 @@ final class NetworkManager {
         do {
             if (200...299).contains(statusCode) {
                 let successResponse = try JSONDecoder().decode(T.self, from: response.data!)
+                
+                NetworkLog.success(url: requestURL.path, statusCode: statusCode, data: successResponse)
+                
                 return .success(successResponse)
             } else {
                 var errorResponse = try JSONDecoder().decode(EstateErrorResponseDTO.self, from: response.data!)
                 errorResponse.statusCode = statusCode
+                
+                NetworkLog.failure(url: requestURL.path, statusCode: statusCode, data: errorResponse)
+                
                 return .failure(errorResponse)
             }
         } catch {
@@ -53,10 +59,16 @@ final class NetworkManager {
         do {
             if (200...299).contains(statusCode) {
                 let successResponse = try JSONDecoder().decode(T.self, from: response.data!)
+                
+                NetworkLog.success(url: requestURL.path, statusCode: statusCode, data: successResponse)
+                
                 return .success(successResponse)
             } else {
                 var errorResponse = try JSONDecoder().decode(EstateErrorResponseDTO.self, from: response.data!)
                 errorResponse.statusCode = statusCode
+                
+                NetworkLog.failure(url: requestURL.path, statusCode: statusCode, data: errorResponse)
+                
                 return .failure(errorResponse)
             }
         } catch {
@@ -65,3 +77,47 @@ final class NetworkManager {
     }
 }
 
+#if DEBUG
+private enum NetworkLog {
+    
+    private static let isPrint = true
+    
+    /// 네트워크 성공시 출력합니다.
+    static func success<T: Decodable>(
+        url: String,
+        statusCode: Int,
+        data: T
+    ) {
+        let message = """
+            [✅ SUCCESS]
+            - endPoint: \(url)
+            - statusCode: \(statusCode)
+            =====================================================
+            """
+        
+        if isPrint {
+            print(message)
+            dump(data)
+        }
+    }
+    
+    /// 네트워크 로그를 출력합니다.
+    static func failure<T: Decodable> (
+        url: String,
+        statusCode: Int,
+        data: T
+    ) {
+        let message = """
+            [❌ FAILURE]
+            - endPoint: \(url)
+            - statusCode: \(statusCode)
+            =====================================================
+            """
+        
+        if isPrint {
+            print(message)
+            dump(data)
+        }
+    }
+}
+#endif

--- a/Modungji/Core/Network/NetworkManager.swift
+++ b/Modungji/Core/Network/NetworkManager.swift
@@ -13,7 +13,7 @@ final class NetworkManager {
     
     // TODO: 토큰 Interceptor 기능 넣기
     /// 서버에러 -> Result<Failure>, 그 외 코드 에러  -> throw
-    static func requestEstate<T: Decodable>(requestURL: APIRouter, successDecodingType: T.Type) async throws -> Result<T, EstateErrorResponseDTO> {
+    func requestEstate<T: Decodable>(requestURL: APIRouter, successDecodingType: T.Type) async throws -> Result<T, EstateErrorResponseDTO> {
         
         let response = await AF.request(requestURL)
             .serializingData()
@@ -37,7 +37,7 @@ final class NetworkManager {
         }
     }
     
-    static func requestEstateMultiPart<T: Decodable>(requestURL: APIRouter, imageData: Data, successDecodingType: T.Type) async throws -> Result<T, EstateErrorResponseDTO> {
+    func requestEstateMultiPart<T: Decodable>(requestURL: APIRouter, imageData: Data, successDecodingType: T.Type) async throws -> Result<T, EstateErrorResponseDTO> {
         
         let multipartFormData = MultipartFormData()
         multipartFormData.append(imageData, withName: "profileImage.png")

--- a/Modungji/Core/Network/Router/Estate/Auth.swift
+++ b/Modungji/Core/Network/Router/Estate/Auth.swift
@@ -52,11 +52,12 @@ extension EstateRouter {
             
             switch self {
             case .renewToken:
+                let keychainManager = KeychainManager()
                 do {
-                    let accessToken = try KeychainManager.getToken(tokenType: .accessToken)
+                    let accessToken = try keychainManager.getToken(tokenType: .accessToken)
                     headers.add(name: "Authorization", value: accessToken)
                     
-                    let refreshToken = try KeychainManager.getToken(tokenType: .refreshToken)
+                    let refreshToken = try keychainManager.getToken(tokenType: .refreshToken)
                     headers.add(name: "RefreshToken", value: refreshToken)
                 } catch {
                     // TODO: KeychainError 에러처리

--- a/Modungji/Core/Network/Router/Estate/User.swift
+++ b/Modungji/Core/Network/Router/Estate/User.swift
@@ -102,11 +102,13 @@ extension EstateRouter {
                 break
             }
             
+            let keychainManager = KeychainManager()
+            
             switch self {
             case .updateDeviceToken, .getOtherProfile, .getMyProfile,
                     .updateMyProfile:
                 do {
-                    let token = try KeychainManager.getToken(tokenType: .accessToken)
+                    let token = try keychainManager.getToken(tokenType: .accessToken)
                     headers.add(name: "Authorization", value: token)
                 } catch {
                     // TODO: KeychainError 에러처리
@@ -114,7 +116,7 @@ extension EstateRouter {
                 }
             case .uploadProfileImage:
                 do {
-                    let token = try KeychainManager.getToken(tokenType: .accessToken)
+                    let token = try keychainManager.getToken(tokenType: .accessToken)
                     headers.add(name: "Authorization", value: token)
                 } catch {
                     // TODO: KeychainError 에러처리

--- a/Modungji/Feature/Auth/Model/EstateErrorResponseEntity.swift
+++ b/Modungji/Feature/Auth/Model/EstateErrorResponseEntity.swift
@@ -1,0 +1,13 @@
+//
+//  EstateErrorResponseEntity.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+struct EstateErrorResponseEntity: Error {
+    let message: String
+    var statusCode: Int?
+}

--- a/Modungji/Feature/Auth/Model/LoginResponseEntity.swift
+++ b/Modungji/Feature/Auth/Model/LoginResponseEntity.swift
@@ -1,0 +1,17 @@
+//
+//  LoginResponseEntity.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+struct LoginResponseEntity {
+    let user_id: String
+    let email: String
+    let nick: String
+    let profileImage: String?
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Modungji/Feature/Auth/Model/LoginWithEmailRequestEntity.swift
+++ b/Modungji/Feature/Auth/Model/LoginWithEmailRequestEntity.swift
@@ -1,0 +1,13 @@
+//
+//  LoginWithEmailRequestEntity.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+struct LoginWithEmailRequestEntity {
+    var email: String
+    var password: String
+}

--- a/Modungji/Feature/Auth/Model/SignUpWithEmailRequestEntity.swift
+++ b/Modungji/Feature/Auth/Model/SignUpWithEmailRequestEntity.swift
@@ -1,0 +1,14 @@
+//
+//  SignUpWithEmailRequestEntity.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+struct SignUpWithEmailRequestEntity {
+    var email: String
+    var password: String
+    var nickname: String
+}

--- a/Modungji/Feature/Auth/Model/SignUpWithEmailResponseEntity.swift
+++ b/Modungji/Feature/Auth/Model/SignUpWithEmailResponseEntity.swift
@@ -1,0 +1,16 @@
+//
+//  SignUpWithEmailResponseEntity.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+struct SignUpWithEmailResponseEntity {
+    let user_id: String
+    let email: String
+    let nick: String
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Modungji/Feature/Auth/Model/ValidateEmailResponseEntity.swift
+++ b/Modungji/Feature/Auth/Model/ValidateEmailResponseEntity.swift
@@ -1,0 +1,13 @@
+//
+//  ValidateEmailResponseEntity.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+struct ValidateEmailResponseEntity {
+    let isValid: Bool
+    let message: String 
+}

--- a/Modungji/Feature/Auth/Repository/AuthRepository.swift
+++ b/Modungji/Feature/Auth/Repository/AuthRepository.swift
@@ -1,0 +1,19 @@
+//
+//  AuthRepository.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+import Alamofire
+
+protocol AuthRepository {
+    func checkEmailValidation(request: ValidateEmailRequestDTO) async throws -> ValidateEmailResponseEntity
+    func authWithApple(request: LoginWithAppleRequestDTO) async throws -> LoginResponseEntity
+    func authWithKakao() async throws -> LoginResponseEntity
+    func loginWithEmail(request: LoginWithEmailRequestDTO) async throws -> LoginResponseEntity
+    func saveToken(accessToken: String, refreshToken: String) async throws
+    @discardableResult func signUpWithEmail(request: JoinRequestDTO) async throws -> SignUpWithEmailResponseEntity
+}

--- a/Modungji/Feature/Auth/Repository/AuthRepositoryImp.swift
+++ b/Modungji/Feature/Auth/Repository/AuthRepositoryImp.swift
@@ -1,0 +1,99 @@
+//
+//  AuthRepositoryImp.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import Foundation
+
+import Alamofire
+
+final class AuthRepositoryImp: AuthRepository {
+    
+    private let networkManager: NetworkManager
+    private let kakaoManager: KakaoManager
+    private let keychainManager: KeychainManager
+    
+    init(networkManager: NetworkManager, kakaoManager: KakaoManager, keychainManger: KeychainManager) {
+        self.networkManager = networkManager
+        self.kakaoManager = kakaoManager
+        self.keychainManager = keychainManger
+    }
+    
+    func checkEmailValidation(request: ValidateEmailRequestDTO) async throws -> ValidateEmailResponseEntity {
+        
+        let response = try await self.networkManager.requestEstate(requestURL: EstateRouter.User.validateEmail(body: request), successDecodingType: ValidateEmailResponseDTO.self)
+        
+        switch response {
+        case .success(let success):
+            return ValidateEmailResponseEntity(isValid: true, message: success.message)
+        case .failure(let failure):
+            return ValidateEmailResponseEntity(isValid: false, message: failure.message)
+        }
+    }
+    
+    func authWithApple(request: LoginWithAppleRequestDTO) async throws -> LoginResponseEntity {
+        
+        let response = try await self.networkManager.requestEstate(requestURL: EstateRouter.User.loginWithApple(body: request), successDecodingType: LoginResponseDTO.self)
+        
+        switch response {
+        case .success(let success):
+            
+            return LoginResponseEntity(user_id: success.user_id, email: success.email, nick: success.nick, profileImage: success.profileImage, accessToken: success.accessToken, refreshToken: success.refreshToken)
+        case .failure(let failure):
+            throw EstateErrorResponseEntity(message: failure.message, statusCode: failure.statusCode)
+        }
+    }
+    
+    func authWithKakao() async throws -> LoginResponseEntity {
+        let token = await self.kakaoManager.requestLogin()
+        
+        guard let token else {
+            throw EstateErrorResponseEntity(message: "카카오 로그인 실패")
+        }
+        
+        let request = LoginWithKakaoRequestDTO(oauthToken: token.accessToken)
+        
+        let response = try await self.networkManager.requestEstate(requestURL: EstateRouter.User.loginWithKakao(body: request), successDecodingType: LoginResponseDTO.self)
+        
+        switch response {
+        case .success(let success):
+            return LoginResponseEntity(user_id: success.user_id, email: success.email, nick: success.nick, profileImage: success.profileImage, accessToken: success.accessToken, refreshToken: success.refreshToken)
+        case .failure(let failure):
+            throw EstateErrorResponseEntity(message: failure.message, statusCode: failure.statusCode)
+        }
+    }
+    
+    func loginWithEmail(request: LoginWithEmailRequestDTO) async throws -> LoginResponseEntity {
+        let response = try await self.networkManager.requestEstate(requestURL: EstateRouter.User.loginWithEmail(body: request), successDecodingType: LoginResponseDTO.self)
+        
+        switch response {
+        case .success(let success):
+            
+            return LoginResponseEntity(user_id: success.user_id, email: success.email, nick: success.nick, profileImage: success.profileImage, accessToken: success.accessToken, refreshToken: success.refreshToken)
+        case .failure(let failure):
+            throw EstateErrorResponseEntity(message: failure.message, statusCode: failure.statusCode)
+        }
+    }
+    
+    func saveToken(accessToken: String, refreshToken: String) async throws {
+        do {
+            try self.keychainManager.saveToken(tokenType: .accessToken, token: accessToken)
+            try self.keychainManager.saveToken(tokenType: .refreshToken, token: refreshToken)
+        } catch {
+            throw EstateErrorResponseEntity(message: "토큰 저장 실패")
+        }
+    }
+    
+    func signUpWithEmail(request: JoinRequestDTO) async throws -> SignUpWithEmailResponseEntity {
+        let response = try await self.networkManager.requestEstate(requestURL: EstateRouter.User.join(body: request), successDecodingType: JoinResponseDTO.self)
+        
+        switch response {
+        case .success(let success):
+            return SignUpWithEmailResponseEntity(user_id: success.user_id, email: success.email, nick: success.nick, accessToken: success.accessToken, refreshToken: success.refreshToken)
+        case .failure(let failure):
+            throw EstateErrorResponseEntity(message: failure.message, statusCode: failure.statusCode)
+        }
+    }
+}

--- a/Modungji/Feature/Auth/Service/AuthService.swift
+++ b/Modungji/Feature/Auth/Service/AuthService.swift
@@ -1,0 +1,22 @@
+//
+//  AuthService.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import AuthenticationServices
+import Foundation
+
+protocol AuthService {
+    func checkEmailValidation(_ email: String) async throws -> ValidateEmailResponseEntity
+    func authWithApple(result: Result<ASAuthorization, any Error>) async throws -> LoginResponseEntity
+    func authWithKakao() async throws -> LoginResponseEntity
+    func loginWithEmail(request: LoginWithEmailRequestEntity) async throws -> LoginResponseEntity
+    
+    /// 회원가입 후, 바로 자동 로그인
+    func signUpWithEmail(request: SignUpWithEmailRequestEntity) async throws -> LoginResponseEntity
+    
+    func checkPasswordValidation(password: String) -> Bool
+    func checkPasswordCheckMatch(password: String, passwordCheck: String) -> Bool
+}

--- a/Modungji/Feature/Auth/Service/AuthServiceImp.swift
+++ b/Modungji/Feature/Auth/Service/AuthServiceImp.swift
@@ -1,0 +1,103 @@
+//
+//  AuthServiceImp.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+
+import AuthenticationServices
+import Foundation
+
+final class AuthServiceImp: AuthService {
+    
+    let repository: AuthRepository
+    
+    init(repository: AuthRepository) {
+        self.repository = repository
+    }
+    
+    func checkEmailValidation(_ email: String) async throws -> ValidateEmailResponseEntity {
+        
+        if email.isEmpty {
+            return ValidateEmailResponseEntity(isValid: false, message: "이메일을 입력해주세요.")
+        }
+        
+//        let emailPattern = "^[A-Za-z0-9]+@[A-Za-z0-9.]+(?:\\.[A-Za-z0-9]+)*\\.[A-Za-z]{2,}$"
+        let emailPattern = /^[A-Za-z0-9]+@[A-Za-z0-9.]+(?:\.[A-Za-z0-9]+)*\.[A-Za-z]{2,}$/
+        if email.wholeMatch(of: emailPattern) == nil {
+            return ValidateEmailResponseEntity(isValid: false, message: "유효하지 않은 이메일")
+        }
+        
+        return try await self.repository.checkEmailValidation(request: ValidateEmailRequestDTO(email: email))
+    }
+    
+    func authWithApple(result: Result<ASAuthorization, any Error>) async throws -> LoginResponseEntity {
+        switch result {
+        case .success(let success):
+            guard let appleIDCredential = success.credential as? ASAuthorizationAppleIDCredential else {
+                throw EstateErrorResponseEntity(message: "애플 로그인 실패")
+            }
+            
+            guard let token = String(data: appleIDCredential.identityToken ?? Data(), encoding: .utf8) else {
+                throw EstateErrorResponseEntity(message: "애플 로그인 실패")
+            }
+            
+            var request = LoginWithAppleRequestDTO(idToken: token)
+            
+            if let first = appleIDCredential.fullName?.givenName, let family = appleIDCredential.fullName?.familyName {
+                request.nick = "\(family) \(first)"
+            }
+            
+            let response = try await self.repository.authWithApple(request: request)
+            
+            try await self.repository.saveToken(accessToken: response.accessToken, refreshToken: response.refreshToken)
+            
+            return response
+            
+        case .failure:
+            throw EstateErrorResponseEntity(message: "애플 로그인 실패")
+        }
+    }
+    
+    func authWithKakao() async throws -> LoginResponseEntity {
+        let response = try await self.repository.authWithKakao()
+
+        try await self.repository.saveToken(accessToken: response.accessToken, refreshToken: response.refreshToken)
+        
+        return response
+    }
+    
+    func loginWithEmail(request: LoginWithEmailRequestEntity) async throws -> LoginResponseEntity {
+        
+        let requestDTO = LoginWithEmailRequestDTO(email: request.email, password: request.password)
+        let response = try await self.repository.loginWithEmail(request: requestDTO)
+        
+        try await self.repository.saveToken(accessToken: response.accessToken, refreshToken: response.refreshToken)
+        
+        return response
+    }
+    
+    func signUpWithEmail(request: SignUpWithEmailRequestEntity) async throws -> LoginResponseEntity {
+        let requestDTO = JoinRequestDTO(email: request.email, password: request.password, nick: request.nickname)
+        
+        try await self.repository.signUpWithEmail(request: requestDTO)
+        
+        let response = try await self.repository.loginWithEmail(request: LoginWithEmailRequestDTO(email: request.email, password: request.password))
+        
+        return response
+    }
+    
+    
+    func checkPasswordValidation(password: String) -> Bool {
+        let passwordPattern = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*#?&]).{8,}$/
+        
+        if password.wholeMatch(of: passwordPattern) == nil {
+            return false
+        }
+        return true
+    }
+    
+    func checkPasswordCheckMatch(password: String, passwordCheck: String) -> Bool {
+        return !password.isEmpty && (password == passwordCheck)
+    }
+}

--- a/Modungji/Feature/Auth/View/AppleLoginButtonView.swift
+++ b/Modungji/Feature/Auth/View/AppleLoginButtonView.swift
@@ -9,22 +9,13 @@ import AuthenticationServices
 import SwiftUI
 
 struct AppleLoginButtonView: View {
+    @EnvironmentObject var viewModel: AuthViewModel
+    
     var body: some View {
         SignInWithAppleButton(.signIn) { request in
             request.requestedScopes = [.email, .fullName]
         } onCompletion: { result in
-            switch result {
-            case .success(let authorization):
-                if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-                    print(appleIDCredential.email ?? "No email")
-                    print(appleIDCredential.fullName ?? "No full name")
-                    
-                    let token = String(data: appleIDCredential.identityToken ?? Data(), encoding: .utf8) ?? "No identity token"
-                    print(token)
-                }
-            case .failure(let error):
-                print(error)
-            }
+            self.viewModel.action(.authWithApple(result: result))
         }
     }
 }

--- a/Modungji/Feature/Auth/View/KakaoLoginButtonView.swift
+++ b/Modungji/Feature/Auth/View/KakaoLoginButtonView.swift
@@ -10,36 +10,11 @@ import SwiftUI
 import KakaoSDKUser
 
 struct KakaoLoginButtonView: View {
+    @EnvironmentObject var viewModel: AuthViewModel
+    
     var body: some View {
         Button {
-            // 카카오톡 설치 여부 체크
-            if UserApi.isKakaoTalkLoginAvailable() {
-                // 카카오톡으로 로그인
-                UserApi.shared.loginWithKakaoTalk { token, error in
-                    if let error {
-                        print(error)
-                        return
-                    }
-                    
-                    guard let token else {
-                        print("Token is nil")
-                        return
-                    }
-                }
-            } else {
-                // 카카오 계정으로 로그인
-                UserApi.shared.loginWithKakaoAccount { token, error in
-                    if let error {
-                        print(error)
-                        return
-                    }
-                    
-                    guard let token else {
-                        print("Token is nil")
-                        return
-                    }
-                }
-            }
+            viewModel.action(.authWithKakao)
         } label: {
             Image(.kakaoLoginButton)
                 .resizable()

--- a/Modungji/Feature/Auth/View/PasswordTextFieldView.swift
+++ b/Modungji/Feature/Auth/View/PasswordTextFieldView.swift
@@ -31,6 +31,7 @@ struct PasswordTextFieldView: View {
             
             self.secureButtonView()
         }
+        .keyboardType(.alphabet)
     }
     
     private func secureButtonView() -> some View {

--- a/Modungji/Feature/Auth/View/SignInUpWithEmailView.swift
+++ b/Modungji/Feature/Auth/View/SignInUpWithEmailView.swift
@@ -8,10 +8,7 @@
 import SwiftUI
 
 struct SignInUpWithEmailView: View {
-    @State private var email: String = ""
-    @State private var nickname: String = ""
-    @State private var password: String = ""
-    @State private var passwordCheck: String = ""
+    @EnvironmentObject var viewModel: AuthViewModel
     
     private let isSignUp: Bool
     
@@ -20,24 +17,58 @@ struct SignInUpWithEmailView: View {
     }
     
     var body: some View {
-        VStack(spacing: 20) {
-            Group {
-                TextField("이메일", text: self.$email)
-                
-                if self.isSignUp {
-                    TextField("닉네임", text: self.$nickname)
+        VStack(alignment: .leading) {
+            TextField("이메일", text: self.$viewModel.input.email)
+                .padding(8)
+                .frame(height: 50)
+                .background(alignment: .bottom) {
+                    Rectangle().foregroundStyle(.gray100).frame(height: 1)
                 }
-
-                PasswordTextFieldView(password: self.$password, isPasswordCheck: false)
-                    
-                if self.isSignUp {
-                    PasswordTextFieldView(password: self.$passwordCheck, isPasswordCheck: true)
-                }
+            
+            if self.isSignUp {
+                Text(self.viewModel.state.validateEmailResponseEntity.message)
+                    .foregroundStyle(self.viewModel.state.validateEmailResponseEntity.isValid ? .blue : .red)
+                    .font(PDFont.caption1)
+                    .padding([.top, .leading], 8)
             }
-            .padding(8)
-            .frame(height: 50)
-            .background(alignment: .bottom) {
-                Rectangle().foregroundStyle(.gray100).frame(height: 1)
+            
+            if self.isSignUp {
+                TextField("닉네임", text: self.$viewModel.input.nickname)
+                    .padding(8)
+                    .frame(height: 50)
+                    .background(alignment: .bottom) {
+                        Rectangle().foregroundStyle(.gray100).frame(height: 1)
+                    }
+                Text("닉네임을 입력해주세요.")
+                    .foregroundStyle(self.viewModel.input.nickname.isEmpty ? .red : .blue)
+                    .font(PDFont.caption1)
+                    .padding([.top, .leading], 8)
+            }
+
+            PasswordTextFieldView(password: self.$viewModel.input.password, isPasswordCheck: false)
+                .padding(8)
+                .frame(height: 50)
+                .background(alignment: .bottom) {
+                    Rectangle().foregroundStyle(.gray100).frame(height: 1)
+                }
+            if self.isSignUp {
+                Text("최소 8자 이상이며, 영문자, 숫자, 특수문자(@$!%*#?&)를 각각 1개 이상 포함")
+                    .foregroundStyle(self.viewModel.state.isValidatePassword ? .blue : .red)
+                    .font(PDFont.caption1)
+                    .padding([.top, .leading], 8)
+            }
+                
+            if self.isSignUp {
+                PasswordTextFieldView(password: self.$viewModel.input.passwordCheck, isPasswordCheck: true)
+                    .padding(8)
+                    .frame(height: 50)
+                    .background(alignment: .bottom) {
+                        Rectangle().foregroundStyle(.gray100).frame(height: 1)
+                    }
+                Text("동일한 비밀번호를 입력해주세요.")
+                    .foregroundStyle(self.viewModel.state.isMatchPasswordCheck ? .blue : .red)
+                    .font(PDFont.caption1)
+                    .padding([.top, .leading], 8)
             }
             
             Spacer()
@@ -47,11 +78,21 @@ struct SignInUpWithEmailView: View {
         .tint(.gray100)
         .font(PDFont.body2)
         .padding(20)
+        .onAppear {
+            self.viewModel.input.isSignUp = self.isSignUp
+        }
+        .onDisappear {
+            self.viewModel.action(.resetInput)
+        }
     }
     
     private func signUpWithEmailButtonView() -> some View {
         Button {
-            
+            if isSignUp {
+                viewModel.action(.signUpWithEmail)
+            } else {
+                viewModel.action(.loginWithEmail)
+            }
         } label: {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(lineWidth: 1)
@@ -60,5 +101,15 @@ struct SignInUpWithEmailView: View {
                     Text(self.isSignUp ? "이메일로 회원가입" : "이메일로 로그인")
                 }
         }
+        // TODO: ViewModel로 빼야하나?
+        .disabled(
+            {
+                if self.isSignUp {
+                    return !(self.viewModel.state.isValidatePassword && self.viewModel.state.isMatchPasswordCheck && self.viewModel.state.validateEmailResponseEntity.isValid && !self.viewModel.input.nickname.isEmpty)
+                } else {
+                    return self.viewModel.input.email.isEmpty || self.viewModel.input.password.isEmpty
+                }
+            }()
+        )
     }
 }

--- a/Modungji/Feature/Auth/View/SignInView.swift
+++ b/Modungji/Feature/Auth/View/SignInView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SignInView: View {
+    @EnvironmentObject var viewModel: AuthViewModel
+    
     var body: some View {
         VStack(spacing: 20) {
             Group {
@@ -18,9 +20,14 @@ struct SignInView: View {
                 EmailLoginButtonView()
             }
             .frame(height: 50)
-            .padding(.horizontal, 20)
             
             EmailSignUpButtonView()
+        }
+        .padding(20)
+        .alert("에러", isPresented: self.$viewModel.state.showErrorAlert) {
+            Button("확인", role: .cancel) { }
+        } message: {
+            Text(self.viewModel.state.errorMessage)
         }
     }
 }

--- a/Modungji/Feature/Auth/ViewModel/AuthViewModel.swift
+++ b/Modungji/Feature/Auth/ViewModel/AuthViewModel.swift
@@ -1,0 +1,184 @@
+//
+//  AuthViewModel.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/19/25.
+//
+import Combine
+import Foundation
+import AuthenticationServices
+
+final class AuthViewModel: ObservableObject {
+    
+    struct State {
+        var showErrorAlert: Bool = false
+        var errorMessage: String = ""
+        var validateEmailResponseEntity: ValidateEmailResponseEntity = ValidateEmailResponseEntity(isValid: false, message: "")
+        var loginResponseEntity: LoginResponseEntity = LoginResponseEntity(user_id: "", email: "", nick: "", profileImage: nil, accessToken: "", refreshToken: "")
+        var isValidatePassword: Bool = false
+        var isMatchPasswordCheck: Bool = false
+    }
+    
+    struct Input {
+        var email: String = ""
+        var password: String = ""
+        var passwordCheck: String = ""
+        var nickname: String = ""
+        var isSignUp: Bool = true
+    }
+    
+    enum Action {
+        case authWithApple(result: Result<ASAuthorization, any Error>)
+        case authWithKakao
+        case loginWithEmail
+        case signUpWithEmail
+        case resetInput
+    }
+    
+    @Published var state: State = State()
+    @Published var input: Input = Input()
+    private var cancellables: Set<AnyCancellable> = []
+    private let service: AuthService
+    
+    init(service: AuthService) {
+        self.service = service
+        self.transform()
+    }
+    
+    private func transform() {
+        Publishers.CombineLatest(self.$input.map(\.email), self.$input.map(\.isSignUp))
+            .filter { email, isSignUp in
+                return isSignUp
+            }
+            .map(\.0)
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .removeDuplicates()
+            .flatMap { [weak self] email -> AnyPublisher<ValidateEmailResponseEntity, NetworkError> in
+                guard let self else {
+                    return Fail(error: .unknown)
+                        .eraseToAnyPublisher()
+                }
+                
+                return Future { promise in
+                    Task {
+                        do {
+                            let result = try await self.service.checkEmailValidation(email)
+                            promise(.success(result))
+                        } catch {
+                            promise(.failure(.unknown))
+                        }
+                    }
+                }
+                .receive(on: DispatchQueue.main)
+                .eraseToAnyPublisher()
+            }
+            .catch { error in
+                self.state.errorMessage = "잠시 후, 다시 시도해주세요."
+                self.state.showErrorAlert = true
+                
+                return Just(ValidateEmailResponseEntity(isValid: false, message: "")).eraseToAnyPublisher()
+            }
+            .sink { [weak self] entity in
+                guard let self, !entity.message.isEmpty else {
+                    return
+                }
+                self.state.validateEmailResponseEntity = entity
+            }
+            .store(in: &self.cancellables)
+        
+        Publishers.CombineLatest(self.$input.map(\.password), self.$input.map(\.passwordCheck))
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .removeDuplicates { previous, current in
+                previous.0 == current.0 && previous.1 == current.1
+            }
+            .sink { [weak self] pw, pwc in
+                guard let self else {
+                    return
+                }
+                self.state.isValidatePassword = self.service.checkPasswordValidation(password: pw)
+                self.state.isMatchPasswordCheck = self.service.checkPasswordCheckMatch(password: pw, passwordCheck: pwc)
+            }
+            .store(in: &self.cancellables)
+    }
+    
+    func action(_ action: Action) {
+        self.state.errorMessage = ""
+        switch action {
+        case .authWithApple(let result):
+            self.authWithApple(result: result)
+        case .authWithKakao:
+            self.authWithKakao()
+        case .loginWithEmail:
+            self.loginWithEmail()
+        case .signUpWithEmail:
+            self.signUpWithEmail()
+        case .resetInput:
+            self.input = Input()
+        }
+    }
+    
+    private func authWithApple(result: Result<ASAuthorization, any Error>) {
+        Task {
+            do {
+                let result = try await self.service.authWithApple(result: result)
+                await MainActor.run {
+                    self.state.loginResponseEntity = result
+                }
+            } catch let error as EstateErrorResponseEntity {
+                await MainActor.run {
+                    self.state.errorMessage = error.message
+                    self.state.showErrorAlert = true
+                }
+            }
+        }
+    }
+    
+    private func authWithKakao() {
+        Task { @MainActor in
+            do {
+                let result = try await self.service.authWithKakao()
+                
+                self.state.loginResponseEntity = result
+                
+            } catch let error as EstateErrorResponseEntity {
+                self.state.errorMessage = error.message
+                self.state.showErrorAlert = true
+            }
+        }
+    }
+    
+    private func loginWithEmail() {
+        Task {
+            do {
+                let request = LoginWithEmailRequestEntity(email: self.input.email, password: self.input.password)
+                
+                let result = try await self.service.loginWithEmail(request: request)
+                await MainActor.run {
+                    self.state.loginResponseEntity = result
+                }
+            } catch let error as EstateErrorResponseEntity {
+                await MainActor.run {
+                    self.state.errorMessage = error.message
+                    self.state.showErrorAlert = true
+                }
+            }
+        }
+    }
+    
+    private func signUpWithEmail() {
+        Task {
+            do {
+                let request = SignUpWithEmailRequestEntity(email: self.input.email, password: self.input.password, nickname: self.input.nickname)
+                let result = try await self.service.signUpWithEmail(request: request)
+                await MainActor.run {
+                    self.state.loginResponseEntity = result
+                }
+            } catch let error as EstateErrorResponseEntity {
+                await MainActor.run {
+                    self.state.errorMessage = error.message
+                    self.state.showErrorAlert = true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 트러블 슈팅
<!-- 진행한 트러블 슈팅이 있다면 작성해주세요. -->
- `@State`와 `@StateObject` 차이와 `@StateObject`는 왜 init에서 초기화가 안될까?
- Combine에서 map 오퍼레이터와 flatmap 오퍼레이터의 차이는?
- ViewModel에서 Input과 State 기준은?
- 애플 로그인 버튼에서 로그인 로직을 분리하지 못할까?

# TODO
<!-- Issue TODO에서 진행한 사항들을 체크해주세요. -->
- [x] Manager 클래스(Network, Keychain) 싱글톤 패턴 제거
- [x] KakaoManager(카카오 로그인 로직 담당) 클래스 생성
- [x] NetworkError unknown case 추가
- [x] NetworkLog(네트워크 로그 출력 담당) 구현
- [x] Auth 관련 뷰에서 사용하는 Entity 구현
- [x] AuthRepository 구현
- [x] AuthService 구현
- [x] AuthViewModel 구현
- [x] 이메일 로그인/회원가입 뷰 UI 수정
- [x] Alert 기능 추가
- [x] 비밀번호 입력 Field 키보드 타입 영어로 고정

# 참고
<!-- 참고한 사항이 있다면 작성해주세요. -->
- 정규식 표현 방식: NSRegularExpression, Regex(Swift 5.7+)
- View <-> ViewModel <-> Service <-> Repository <-> Manager
- ViewModel에서 Output 구조체의 프로퍼티가 Swift 기본 타입이 아닌 구조체일 경우
Output 인스턴스가 @Published이더라도 구조체 프로퍼티의 프로퍼티가 바뀐 경우는 감지하지 못하기 때문에 구조체 프로퍼티에 새로운 인스턴스를 넣어줘야 감지가 된다.