### PR TITLE
Issue/#19/naver maps sdk 적용

### DIFF
--- a/Modungji.xcodeproj/project.pbxproj
+++ b/Modungji.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		517AED772DCDF0DA005646A1 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 517AED762DCDF0DA005646A1 /* .gitignore */; };
 		519B08AD2DD726A000CDDF38 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 519B08AC2DD726A000CDDF38 /* KakaoSDK */; };
 		519B0FB32DD79C6B00CDDF38 /* ModungjiSecret in Frameworks */ = {isa = PBXBuildFile; productRef = 519B0FB22DD79C6B00CDDF38 /* ModungjiSecret */; };
+		51DD39792DE9A32500CCD1FE /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 51DD39782DE9A32500CCD1FE /* NMapsMap */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +46,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5101A8B92DD09E4F008CF16B /* Alamofire in Frameworks */,
+				51DD39792DE9A32500CCD1FE /* NMapsMap in Frameworks */,
 				519B0FB32DD79C6B00CDDF38 /* ModungjiSecret in Frameworks */,
 				519B08AD2DD726A000CDDF38 /* KakaoSDK in Frameworks */,
 			);
@@ -94,6 +96,7 @@
 				5101A8B82DD09E4F008CF16B /* Alamofire */,
 				519B08AC2DD726A000CDDF38 /* KakaoSDK */,
 				519B0FB22DD79C6B00CDDF38 /* ModungjiSecret */,
+				51DD39782DE9A32500CCD1FE /* NMapsMap */,
 			);
 			productName = Modungji;
 			productReference = 517AED4A2DCDEF36005646A1 /* Modungji.app */;
@@ -127,6 +130,7 @@
 				5101A8B72DD09E4F008CF16B /* XCRemoteSwiftPackageReference "Alamofire" */,
 				519B08AB2DD726A000CDDF38 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				519B0FB12DD79C6B00CDDF38 /* XCLocalSwiftPackageReference "ModungjiSecret" */,
+				51DD39772DE9A32500CCD1FE /* XCRemoteSwiftPackageReference "SPM-NMapsMap" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 517AED4B2DCDEF36005646A1 /* Products */;
@@ -426,6 +430,14 @@
 				minimumVersion = 2.24.2;
 			};
 		};
+		51DD39772DE9A32500CCD1FE /* XCRemoteSwiftPackageReference "SPM-NMapsMap" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/navermaps/SPM-NMapsMap";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.21.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -442,6 +454,11 @@
 		519B0FB22DD79C6B00CDDF38 /* ModungjiSecret */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ModungjiSecret;
+		};
+		51DD39782DE9A32500CCD1FE /* NMapsMap */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 51DD39772DE9A32500CCD1FE /* XCRemoteSwiftPackageReference "SPM-NMapsMap" */;
+			productName = NMapsMap;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Modungji.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Modungji.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed9bd06da7be86245d264318597dfbdb4c4b4b3f6e5aa22485c297ab7ce53b22",
+  "originHash" : "98a75d9cee07fa8a45b562181b41639630c949f0df596f3d4919e1e5cce619c8",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -17,6 +17,24 @@
       "state" : {
         "revision" : "787763e335949dfad6b721aa04771e22d04e1493",
         "version" : "2.24.2"
+      }
+    },
+    {
+      "identity" : "spm-nmapsgeometry",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/navermaps/SPM-NMapsGeometry.git",
+      "state" : {
+        "revision" : "436d5e2e684f557faf5ef5862fd6633a42d7af11",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "spm-nmapsmap",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/navermaps/SPM-NMapsMap",
+      "state" : {
+        "revision" : "ad89e53fdfec3b8d8994280fb0414b5a7b1c3e8e",
+        "version" : "3.21.0"
       }
     }
   ],

--- a/Modungji/App/Info.plist
+++ b/Modungji/App/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>$(PRODUCT_NAME)에서 현재 위치를 표시하기 위해 위치 권한이 필요합니다.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>$(PRODUCT_NAME)에서 현재 위치를 표시하기 위해 위치 권한이 필요합니다.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/Modungji/App/ModungjiApp.swift
+++ b/Modungji/App/ModungjiApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 import KakaoSDKCommon
 import ModungjiSecret
+import NMapsMap
 
 @main
 struct ModungjiApp: App {
@@ -17,6 +18,9 @@ struct ModungjiApp: App {
     init() {
         // 카카오 SDK 초기화
         KakaoSDK.initSDK(appKey: ModungjiSecret.Kakao.key)
+        
+        // 네이버지도 SDK 클라이언트 ID 지정
+        NMFAuthManager.shared().ncpKeyId = ModungjiSecret.Naver.clientID
     }
     
     var body: some Scene {

--- a/Modungji/App/PathModel.swift
+++ b/Modungji/App/PathModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 final class PathModel: ObservableObject {
     @Published var path: NavigationPath = .init()
     
-    func push(_ path: Path) {
+    func push(_ path: PathType) {
         self.path.append(path)
     }
     

--- a/Modungji/App/PathType.swift
+++ b/Modungji/App/PathType.swift
@@ -1,5 +1,5 @@
 //
-//  Path.swift
+//  PathType.swift
 //  Modungji
 //
 //  Created by 박준우 on 5/28/25.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum Path: Hashable {
+enum PathType: Hashable {
     case auth
     case authWithEmail(authType: AuthWithEmailType)
     case main

--- a/Modungji/App/RootView.swift
+++ b/Modungji/App/RootView.swift
@@ -49,7 +49,7 @@ struct RootView: View {
                         }
                 }
             }
-            .navigationDestination(for: Path.self) { path in
+            .navigationDestination(for: PathType.self) { path in
                 path.view
             }
         }

--- a/Modungji/Core/Location/LocationManager.swift
+++ b/Modungji/Core/Location/LocationManager.swift
@@ -1,0 +1,53 @@
+//
+//  LocationManager.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/31/25.
+//
+
+import CoreLocation
+import Combine
+import UIKit
+
+final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    private let manager: CLLocationManager = CLLocationManager()
+    
+    @Published var authorizationStatus: CLAuthorizationStatus = .notDetermined
+    
+    override init() {
+        super.init()
+        
+        self.authorizationStatus = self.manager.authorizationStatus
+        
+        self.manager.delegate = self
+    }
+    
+    func requestAuthorization() {
+        switch self.authorizationStatus {
+        case .notDetermined:
+            self.manager.requestWhenInUseAuthorization()
+        case .restricted:
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                
+                Task {
+                    await UIApplication.shared.open(url)
+                }
+            }
+        case .denied:
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                
+                Task {
+                    await UIApplication.shared.open(url)
+                }
+            }
+        case .authorizedAlways:
+            break
+        case .authorizedWhenInUse:
+            self.manager.requestAlwaysAuthorization()
+        case .authorized:
+            break
+        @unknown default:
+            break
+        }
+    }
+}

--- a/Modungji/Feature/Map/Model/CoordinateEntity.swift
+++ b/Modungji/Feature/Map/Model/CoordinateEntity.swift
@@ -1,0 +1,13 @@
+//
+//  CoordinateEntity.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/31/25.
+//
+
+import Foundation
+
+struct CoordinateEntity {
+    var latitude: Double
+    var longitude: Double
+}

--- a/Modungji/Feature/Map/View/MapView.swift
+++ b/Modungji/Feature/Map/View/MapView.swift
@@ -1,0 +1,31 @@
+//
+//  MapView.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/31/25.
+//
+
+import SwiftUI
+
+struct MapView: View {
+    @StateObject var viewModel = NaverMapViewModel()
+    
+    var body: some View {
+        VStack{
+            Text("현재 좌표: \(self.viewModel.currentCoord.latitude, specifier: "%.3f"), \(self.viewModel.currentCoord.longitude, specifier: "%.3f")")
+                .padding()
+            
+            NaverMapView(viewModel: self.viewModel)
+                .overlay(alignment: .bottomTrailing) {
+                    Button {
+                        self.viewModel.setPositionMode()
+                    } label: {
+                        Circle()
+                            .fill(.brightCoast)
+                            .frame(width: 50, height: 50)
+                            .padding(20)
+                    }
+                }
+        }
+    }
+}

--- a/Modungji/Feature/Map/View/NaverMapView.swift
+++ b/Modungji/Feature/Map/View/NaverMapView.swift
@@ -10,14 +10,34 @@ import SwiftUI
 import NMapsMap
 
 struct NaverMapView: UIViewRepresentable {
+    @ObservedObject var viewModel: NaverMapViewModel
     
     func makeUIView(context: Context) -> NMFNaverMapView {
-        let naverMap = NMFNaverMapView()
-        
-        return naverMap
+        return getNaverMapView()
     }
     
     func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
         print(#function)
+    }
+    
+    private func getNaverMapView() -> NMFNaverMapView {
+        let naverMap = NMFNaverMapView()
+        
+        // 줌 컨트롤 UI 제거
+        naverMap.showZoomControls = false
+        
+        // 시작 위치 설정
+        let starCoord = NMGLatLng(
+            lat: self.viewModel.currentCoord.latitude,
+            lng: self.viewModel.currentCoord.longitude
+        )
+        let cameraUpdate = NMFCameraUpdate(scrollTo: starCoord)
+        cameraUpdate.animation = .fly
+        naverMap.mapView.moveCamera(cameraUpdate)
+        
+        // viewModel과 연결
+        self.viewModel.setNaverMapView(naverMap.mapView)
+        
+        return naverMap
     }
 }

--- a/Modungji/Feature/Map/View/NaverMapView.swift
+++ b/Modungji/Feature/Map/View/NaverMapView.swift
@@ -1,0 +1,23 @@
+//
+//  NaverMap.swift
+//  Modungji
+//
+//  Created by 박준우 on 5/31/25.
+//
+
+import SwiftUI
+
+import NMapsMap
+
+struct NaverMapView: UIViewRepresentable {
+    
+    func makeUIView(context: Context) -> NMFNaverMapView {
+        let naverMap = NMFNaverMapView()
+        
+        return naverMap
+    }
+    
+    func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
+        print(#function)
+    }
+}

--- a/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
+++ b/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
@@ -9,11 +9,6 @@ import NMapsMap
 
 final class NaverMapViewModel: NSObject, ObservableObject {
     @Published var currentCoord: CoordinateEntity = .init(latitude: 37.5666805, longitude: 126.9784147)
-    @Published var currentMode: NMFMyPositionMode = .disabled {
-        didSet {
-            self.setPositionMode(self.currentMode)
-        }
-    }
     
     private weak var mapView: NMFMapView?
     private var updateWorkItem: DispatchWorkItem?
@@ -26,19 +21,23 @@ final class NaverMapViewModel: NSObject, ObservableObject {
         mapView.addCameraDelegate(delegate: self)
     }
     
-    private func setPositionMode(_ mode: NMFMyPositionMode) {
+    func setPositionMode() {
         guard let mapView else {
             return
         }
-        mapView.positionMode = mode
-        if mode == .normal {
-            DispatchQueue.main.async {
+        
+        if mapView.positionMode == .disabled {
+            mapView.positionMode = .normal
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                 let nmCoord = mapView.locationOverlay.location
                 let cameraUpdate = NMFCameraUpdate(scrollTo: nmCoord)
                 cameraUpdate.animation = .fly
                 
                 mapView.moveCamera(cameraUpdate)
             }
+        } else {
+            mapView.positionMode = .disabled
         }
     }
 }

--- a/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
+++ b/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
@@ -9,6 +9,11 @@ import NMapsMap
 
 final class NaverMapViewModel: NSObject, ObservableObject {
     @Published var currentCoord: CoordinateEntity = .init(latitude: 37.5666805, longitude: 126.9784147)
+    @Published var currentMode: NMFMyPositionMode = .disabled {
+        didSet {
+            self.setPositionMode(self.currentMode)
+        }
+    }
     
     private weak var mapView: NMFMapView?
     private var updateWorkItem: DispatchWorkItem?
@@ -19,6 +24,20 @@ final class NaverMapViewModel: NSObject, ObservableObject {
             return
         }
         mapView.addCameraDelegate(delegate: self)
+    }
+    
+    private func setPositionMode(_ mode: NMFMyPositionMode) {
+        guard let mapView else {
+            return
+        }
+        mapView.positionMode = mode
+        if mode == .normal {
+            let nmCoord = mapView.locationOverlay.location
+            let cameraUpdate = NMFCameraUpdate(scrollTo: nmCoord)
+            cameraUpdate.animation = .fly
+            
+            mapView.moveCamera(cameraUpdate)
+        }
     }
 }
 

--- a/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
+++ b/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
@@ -1,0 +1,29 @@
+//
+//  NaverMapViewModel.swift
+//  Modungji
+//
+//  Created by 박준우 on 6/1/25.
+//
+
+import NMapsMap
+
+final class NaverMapViewModel: NSObject, ObservableObject {
+    @Published var currentCoord: CoordinateEntity = .init(latitude: 37.5666805, longitude: 126.9784147)
+    
+    private weak var mapView: NMFMapView?
+    
+    func setNaverMapView(_ view: NMFMapView) {
+        self.mapView = view
+        guard let mapView else {
+            return
+        }
+        mapView.addCameraDelegate(delegate: self)
+    }
+}
+
+extension NaverMapViewModel: NMFMapViewCameraDelegate {
+    func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
+        let coord = mapView.cameraPosition.target
+        self.currentCoord = .init(latitude: coord.lat, longitude: coord.lng)
+    }
+}

--- a/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
+++ b/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
@@ -11,6 +11,7 @@ final class NaverMapViewModel: NSObject, ObservableObject {
     @Published var currentCoord: CoordinateEntity = .init(latitude: 37.5666805, longitude: 126.9784147)
     
     private weak var mapView: NMFMapView?
+    private var updateWorkItem: DispatchWorkItem?
     
     func setNaverMapView(_ view: NMFMapView) {
         self.mapView = view
@@ -23,7 +24,17 @@ final class NaverMapViewModel: NSObject, ObservableObject {
 
 extension NaverMapViewModel: NMFMapViewCameraDelegate {
     func mapView(_ mapView: NMFMapView, cameraDidChangeByReason reason: Int, animated: Bool) {
-        let coord = mapView.cameraPosition.target
-        self.currentCoord = .init(latitude: coord.lat, longitude: coord.lng)
+        self.updateWorkItem?.cancel()
+        
+        self.updateWorkItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            
+            let coord = mapView.cameraPosition.target
+            self.currentCoord = .init(latitude: coord.lat, longitude: coord.lng)
+        }
+        
+        guard let updateWorkItem else { return }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7, execute: updateWorkItem)
     }
 }

--- a/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
+++ b/Modungji/Feature/Map/ViewModel/NaverMapViewModel.swift
@@ -32,11 +32,13 @@ final class NaverMapViewModel: NSObject, ObservableObject {
         }
         mapView.positionMode = mode
         if mode == .normal {
-            let nmCoord = mapView.locationOverlay.location
-            let cameraUpdate = NMFCameraUpdate(scrollTo: nmCoord)
-            cameraUpdate.animation = .fly
-            
-            mapView.moveCamera(cameraUpdate)
+            DispatchQueue.main.async {
+                let nmCoord = mapView.locationOverlay.location
+                let cameraUpdate = NMFCameraUpdate(scrollTo: nmCoord)
+                cameraUpdate.animation = .fly
+                
+                mapView.moveCamera(cameraUpdate)
+            }
         }
     }
 }


### PR DESCRIPTION
# 트러블 슈팅
<!-- 진행한 트러블 슈팅이 있다면 작성해주세요. -->
- Naver Map SDK에서는 SwiftUI의 View 방식을 지원하지 않아서 `UIViewRepresentable` 방식을 불러왔음
- 위치 권한만 허용되어 있다면, Naver Map SDK에서 현재 위치 마커를 제공함
- 수동으로 Naver Map SDK의 현재 위치 모드 변경 버튼을 구현할 경우 현재 위치로 카메라를 옮기는 것도 수동으로 구현해야함
이 때, 바로 카메라 위치를 현재 위치 좌표로 이동시키면 좌표가 0,0으로 잡히기 때문에 지연실행해야함

# TODO
<!-- Issue TODO에서 진행한 사항들을 체크해주세요. -->
- [x] Naver Dynamic Map SDK 적용

그 외 진행한 사항들
- [x] 위치 권한 요청 문구 추가
- [x] Path 열거형 모델 이름 수정
- [x] CoordinateEntity 구현
- [x] LocationManager 구현

# 참고
<!-- 참고한 사항이 있다면 작성해주세요. -->